### PR TITLE
docs(tf-static-website): polish README - 2 fixes [routine:daily-polish]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md — tf-static-website
+
+## Project Overview
+
+Terraform IaC for deploying [jacobpevans.com](https://jacobpevans.com) as a static website on AWS. Manages S3 (hosting), CloudFront (CDN), Route 53 (DNS), and ACM SSL/TLS. Remote state stored in an encrypted S3 backend.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `main.tf` | Core Terraform configuration (providers, backend, module call) |
+| `.terraform.lock.hcl` | Provider version lock file |
+| `renovate.json` | Renovate dependency-update config (extends org presets) |
+| `s3-files/` | Static website assets deployed to S3 (HTML, CSS, JS) |
+
+## Common Commands
+
+```bash
+# Download providers and modules
+terraform init
+
+# Preview changes before applying
+terraform plan
+
+# Apply infrastructure changes
+terraform apply
+
+# Tear down all managed infrastructure
+terraform destroy
+```
+
+## Architecture Notes
+
+- **Module:** `cloudmaniac/static-website/aws` (Terraform Registry)
+- **Primary domain:** `jacobpevans.com`
+- **Redirect domain:** `www.jacobpevans.com`
+- **State backend:** S3 bucket `jacobpevans-tf-states`, key `static-website`, region `us-east-1`, encrypted
+
+## AWS Configuration
+
+Uses the `default` AWS CLI profile in `us-east-1`. Ensure credentials are configured before running Terraform commands.
+
+## Attribution Conventions
+
+PRs modifying this repo should suffix the title with `[routine:daily-polish]` for automated documentation changes and include a Provenance block in the PR body.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# tf-static-website
+
+Terraform IaC deploying [jacobpevans.com](https://jacobpevans.com) as a static website to AWS. Provisions S3 (hosting), CloudFront (CDN), Route 53 (DNS), and ACM SSL/TLS certificates for HTTPS. State managed in an encrypted S3 backend.
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads) >= 1.x
+- AWS CLI configured with a `default` profile
+- S3 bucket `jacobpevans-tf-states` provisioned for remote state
+
+## Installation
+
+```bash
+terraform init
+```
+
+## Usage
+
+```bash
+# Preview changes
+terraform plan
+
+# Apply infrastructure
+terraform apply
+```
+
+Domains managed by this configuration:
+
+| Domain | Role |
+|--------|------|
+| `jacobpevans.com` | Primary |
+| `www.jacobpevans.com` | Redirect → primary |
+
+## Architecture
+
+| Service | Purpose |
+|---------|---------|
+| S3 | Static file hosting |
+| CloudFront | CDN and HTTPS termination |
+| Route 53 | DNS |
+| ACM | SSL/TLS certificates |
+
+Module: [`cloudmaniac/static-website/aws`](https://registry.terraform.io/modules/cloudmaniac/static-website/aws)
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
Daily Polish auto-generated PR.

## Checks before fix

2/5 passing.

Failing checks: README (missing), CLAUDE.md (missing), Release Hygiene (no releases — out of scope for documentation-only fixes)

## Fixes applied

- README: created `README.md` with description paragraph, prerequisites, installation, usage, architecture table, and license sections
- CLAUDE.md: created `CLAUDE.md` with project overview, key files table, common commands, architecture notes, AWS configuration guidance, and attribution conventions

## Checks after fix (self-verification)

Re-evaluated against the `docs/daily-polish/tf-static-website-2026-05-27` branch: improved from 2 -> 4 passing.

(Release Hygiene remains failing — creating a release is out of scope for documentation-only changes.)

## Provenance

- **Generated by:** [Daily Polish](https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/daily-polish.prompt.md) - cloud routine, daily at 04:00 UTC
- **Triggered:** Scheduled run on 2026-05-27
- **Why this PR:** tf-static-website was selected from the rotation (state gist `daily-polish-state`); 3/5 checks failed.
- **State:** [daily-polish-state gist](https://gist.github.com/JacobPEvans/3973727cb935d2960b17ae2d4e9fbdda)
- **Label:** `cloud-routine`
