### PR TITLE
🤖 Fix #7: Required providers block commented out

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,10 @@
 terraform {
-#  required_providers {
-#    aws = {
-#      source = "hashicorp/aws"
-#    }
-#  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
   backend "s3" {
     bucket  = "jacobpevans-tf-states"
     key     = "static-website"
@@ -24,3 +25,4 @@ module "static-website" {
   website-domain-main     = "jacobpevans.com"
   website-domain-redirect = "www.jacobpevans.com"
 }
+


### PR DESCRIPTION
Closes #7

## Problem

The `required_providers` block in `main.tf` is completely commented out, violating Terraform dependency management best practices. Without an explicit provider source declaration, the configuration is non-reproducible across environments.

```hcl
#  required_providers {
#    aws = {
#      source = "hashicorp/aws"
#    }
#  }
```

## Approach

Uncomment the `required_providers` block and add an explicit `version = "~> 5.0"` constraint for the AWS provider, following the recommended fix from the issue.

## Files changed

- `main.tf` — uncomment required_providers block with hashicorp/aws source and ~> 5.0 version constraint

## CI status

none — no .github/workflows/ present in this repo

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
