### PR TITLE
🤖 Fix #8: HIGH: Module version not pinned

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,8 @@ provider "aws" {
 # Enable bucket versioning
 module "static-website" {
   source                  = "cloudmaniac/static-website/aws"
-#  version = "1.0.1"
+  version                 = "~> 1.0"
   website-domain-main     = "jacobpevans.com"
   website-domain-redirect = "www.jacobpevans.com"
 }
+


### PR DESCRIPTION
Closes #8

## Problem

The module version is commented out in `main.tf`, causing Terraform to always fetch the latest version without testing:

```hcl
module "static-website" {
  source                  = "cloudmaniac/static-website/aws"
#  version = "1.0.1"
```

This means:
- Automatic untested updates from module registry
- Breaking changes could silently fail deployments
- Violates change management practices

## Approach

Uncomment and update the version constraint to `~> 1.0` (allows patch/minor updates within the 1.x range, preventing unexpected major-version breakage).

## Files changed

- `main.tf` — uncomment version pin, update to `~> 1.0` constraint

## CI status

none — no workflows defined

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
