### PR TITLE
docs(tf-static-website): polish README - 2 fixes [routine:daily-polish]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# tf-static-website
+
+Terraform IaC for deploying `jacobpevans.com` as a static website on AWS.
+
+## Architecture
+
+Uses the [`cloudmaniac/static-website/aws`](https://registry.terraform.io/modules/cloudmaniac/static-website/aws) community module, which provisions:
+- S3 bucket for static file hosting
+- CloudFront CDN distribution
+- Route 53 DNS records for primary and redirect domains
+- ACM SSL/TLS certificate (us-east-1, required by CloudFront)
+
+Remote state: S3 bucket `jacobpevans-tf-states`, key `static-website`, region `us-east-1`.
+
+## Common Tasks
+
+- `terraform init` — initialize providers and backend
+- `terraform plan` — preview changes
+- `terraform apply` — apply changes
+- `terraform destroy` — tear down all infrastructure
+
+## Constraints
+
+- Do not commit `.tfvars` files — may contain secrets
+- The `.terraform.lock.hcl` file should be committed to lock provider versions
+- Only modify `.tf` files and documentation (`*.md`)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# tf-static-website
+
+Terraform Infrastructure as Code for deploying a static website to AWS. Provisions S3 (hosting), CloudFront (CDN), Route 53 (DNS), and ACM SSL/TLS certificates for HTTPS. Encrypted S3 backend for remote state management.
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads) >= 1.0
+- AWS credentials configured (`~/.aws/credentials` or environment variables)
+- AWS profile named `default` with appropriate IAM permissions
+
+## Setup
+
+```bash
+terraform init
+```
+
+## Usage
+
+Preview infrastructure changes:
+
+```bash
+terraform plan
+```
+
+Apply the infrastructure:
+
+```bash
+terraform apply
+```
+
+Tear down all resources:
+
+```bash
+terraform destroy
+```
+
+## Configuration
+
+| Setting | Value |
+|---|---|
+| Primary domain | `jacobpevans.com` |
+| Redirect domain | `www.jacobpevans.com` |
+| State backend | S3 `jacobpevans-tf-states` / key `static-website` |
+| Region | `us-east-1` |
+
+This module uses [`cloudmaniac/static-website/aws`](https://registry.terraform.io/modules/cloudmaniac/static-website/aws) from the Terraform Registry.
+
+## License
+
+[Apache 2.0](LICENSE)


### PR DESCRIPTION
Daily Polish auto-generated PR.

## Checks before fix

2/5 passing.

Failing checks: README (missing), CLAUDE.md (missing), Release hygiene (no published releases)

## Fixes applied

- README: Created with description, prerequisites, setup, usage, configuration table, and license sections
- CLAUDE.md: Created with architecture overview, common tasks, and constraints

Note: Release hygiene check not addressable via documentation-only changes.

## Checks after fix (self-verification)

Re-evaluated against the `docs/daily-polish/tf-static-website-2026-05-31` branch: improved from 2 -> 4 passing.

(README now exists with content, CLAUDE.md now exists with useful content, description filled, renovate.json + .gitignore present. Release check still failing — out of scope.)

## Provenance

- **Generated by:** [Daily Polish](https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/daily-polish.prompt.md) - cloud routine, daily at 04:00 UTC
- **Triggered:** Scheduled run on 2026-05-31
- **Why this PR:** tf-static-website was selected from the rotation (state gist `daily-polish-state`); 3/5 checks failed. Tiebreaker: repo had no README (score=1 vs 0 for other candidates).
- **State:** [daily-polish-state gist](https://gist.github.com/JacobPEvans-personal/3973727cb935d2960b17ae2d4e9fbdda)
- **Label:** `cloud-routine`
