### PR TITLE
🤖 Fix #4: Dark mode

### DIFF
--- a/s3-files/css/dark.css
+++ b/s3-files/css/dark.css
@@ -1,0 +1,38 @@
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #1a1a2e;
+        color: #c9d1d9;
+    }
+
+    section.resume-section {
+        background-color: #1a1a2e;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+        color: #e6edf3;
+    }
+
+    a {
+        color: #58a6ff;
+    }
+
+    a:hover {
+        color: #79b9ff;
+    }
+
+    hr {
+        border-color: #30363d;
+    }
+
+    .text-muted {
+        color: #8b949e !important;
+    }
+
+    .social-icons .social-icon {
+        background-color: #30363d;
+    }
+
+    .social-icons .social-icon:hover {
+        background-color: #dc3545;
+    }
+}

--- a/s3-files/index.html
+++ b/s3-files/index.html
@@ -14,6 +14,8 @@
         <link href="https://fonts.googleapis.com/css?family=Muli:400,400i,800,800i" rel="stylesheet" type="text/css" />
         <!-- Core theme CSS (includes Bootstrap)-->
         <link href="css/styles.css" rel="stylesheet" />
+        <!-- Dark mode overrides -->
+        <link href="css/dark.css" rel="stylesheet" />
     </head>
     <body id="page-top">
         <!-- Navigation-->


### PR DESCRIPTION
Closes #4

## Problem

The personal website (`tf-static-website`) has no dark mode support. Users viewing the site with dark mode enabled in their OS/browser preferences see a fully white background, which can be jarring in low-light environments.

## Approach

Create a new `s3-files/css/dark.css` file containing `@media (prefers-color-scheme: dark)` overrides for the body background, section backgrounds, headings, links, horizontal rules, muted text, and social icon buttons. Link the new stylesheet from `s3-files/index.html` after the main Bootstrap bundle so the overrides take effect automatically when the OS dark mode preference is detected — no JS toggle required.

## Files changed

- `s3-files/css/dark.css` — new dark mode stylesheet using CSS media query
- `s3-files/index.html` — add `<link>` tag to load dark.css after styles.css

## CI status

none — no CI workflows configured in this repo

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
