### PR TITLE
docs(tf-static-website): polish README - 2 fixes [routine:daily-polish]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md — tf-static-website
+
+## Repository purpose
+
+Terraform IaC for the jacobpevans.com static website on AWS (S3 + CloudFront + Route 53 + ACM). Single `main.tf` using the `cloudmaniac/static-website/aws` community module.
+
+## Key constraints
+
+- **Do not modify** `s3-files/` — those are the live website source files; changes deploy to production.
+- **Do not modify** `.terraform.lock.hcl` manually; let `terraform init -upgrade` manage it.
+- **State backend** is `s3://jacobpevans-tf-states/static-website` (us-east-1, encrypted). Never run `terraform state` commands without confirming with the repo owner.
+- The `required_providers` block is intentionally commented out; the lock file pins provider versions instead.
+
+## Common tasks
+
+```bash
+terraform init        # initialize / install modules
+terraform validate    # lint HCL
+terraform plan        # preview changes
+terraform apply       # deploy
+```
+
+## Attribution conventions
+
+- PR title suffix: `[routine:daily-polish]` for automated polish PRs
+- Label automated PRs with `cloud-routine`
+- Provenance block required in PR bodies for all automated changes

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# tf-static-website
+
+Terraform IaC that deploys the [jacobpevans.com](https://jacobpevans.com) static website to AWS. Provisions S3 (origin hosting), CloudFront (CDN + HTTPS), Route 53 (DNS), and ACM (SSL/TLS certificates). State is stored in an encrypted S3 backend.
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
+- AWS credentials configured (default profile or `AWS_PROFILE` env var)
+- An existing Route 53 hosted zone for the target domain
+- An S3 bucket for Terraform state (`jacobpevans-tf-states`)
+
+## Setup
+
+```bash
+terraform init
+```
+
+Terraform will download the [`cloudmaniac/static-website/aws`](https://registry.terraform.io/modules/cloudmaniac/static-website/aws/latest) community module and configure the S3 remote backend.
+
+## Usage
+
+```bash
+# Preview changes
+terraform plan
+
+# Apply infrastructure
+terraform apply
+
+# Destroy infrastructure
+terraform destroy
+```
+
+Website source files live in `s3-files/`. After `terraform apply` succeeds, deploy site content to the S3 origin bucket using the AWS CLI or a CI pipeline.
+
+## Architecture
+
+| Resource | Purpose |
+|---|---|
+| S3 bucket | Static file origin |
+| CloudFront | CDN, HTTPS termination |
+| Route 53 | DNS (apex + www redirect) |
+| ACM certificate | SSL/TLS (us-east-1) |
+
+## License
+
+[Apache 2.0](LICENSE)


### PR DESCRIPTION
Daily Polish auto-generated PR.

## Checks before fix

2/5 passing.

Failing checks: README Quality, CLAUDE.md, Release Hygiene

## Fixes applied

- README Quality: added README.md with description, prerequisites, setup, usage, architecture table, and license mention
- CLAUDE.md: added CLAUDE.md with repository purpose, key constraints, common tasks, and attribution conventions

_Note: Release Hygiene (no published releases) is outside documentation scope and was not addressed._

## Checks after fix (self-verification)

Re-evaluated against the `docs/daily-polish/tf-static-website-2026-06-02` branch: improved from 2 -> 4 passing.

## Provenance

- **Generated by:** [Daily Polish](https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/daily-polish.prompt.md) - cloud routine, daily at 04:00 UTC
- **Triggered:** Scheduled run on 2026-06-02
- **Why this PR:** tf-static-website was selected from the rotation (state gist `daily-polish-state`); 3/5 checks failed (tiebreaker probe: missing README scored +1 vs peers).
- **State:** [daily-polish-state gist](https://gist.github.com/JacobPEvans-personal/3973727cb935d2960b17ae2d4e9fbdda)
- **Label:** `cloud-routine`
